### PR TITLE
Swap http-server for browser-sync for SPA behaviour

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -1,0 +1,32 @@
+var historyApiFallback = require('connect-history-api-fallback');
+/*
+ |--------------------------------------------------------------------------
+ | Browser-sync config file
+ |--------------------------------------------------------------------------
+ |
+ | For up-to-date information about the options:
+ |   http://www.browsersync.io/docs/options/
+ |
+ | There are more options than you see here, these are just the ones that are
+ | set internally. See the website for more info.
+ |
+ |
+ */
+module.exports = {
+    "ui": {
+        "port": 8083,
+        "weinre": {
+            "port": 8084
+        }
+    },
+    "files": ['public/**/*.{js,less,stache,html}'],
+    "watchOptions": {},
+    "server": true,
+    "port": 8080,
+    "middleware": [ historyApiFallback() ],
+    "serveStatic": [
+        'public',
+        'node_modules',
+        './'
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "testee public/test/test.html --browsers firefox --reporter Spec",
-    "start": "http-server . --port 8080",
+    "start": "browser-sync start --config bs-config.js",
     "document": "documentjs",
     "build": "node build"
   },
@@ -43,11 +43,13 @@
   },
   "devDependencies": {
     "bootstrap": "^3.3.6",
+    "browser-sync": "^2.14.0",
     "can": "^2.3.15",
     "can-connect": "^0.3.4",
     "can-fixture": "^0.3.2",
     "can-ssr": "^0.11.7",
     "chai": "^3.5.0",
+    "connect-history-api-fallback": "^1.3.0",
     "documentjs": "^0.4.4",
     "done-autorender": "^0.8.0",
     "done-component": "^0.4.0",
@@ -58,7 +60,6 @@
     "es6-math": "^1.0.0",
     "funcunit": "^3.1.0-pre.1",
     "generator-donejs": "^0.4.3",
-    "http-server": "^0.8.5",
     "jquery": "2.1.4",
     "jquery-transport-xdr": "^1.0.9",
     "lodash": "^3.10.1",

--- a/public/app.js
+++ b/public/app.js
@@ -1,5 +1,6 @@
 import route from "can/route/";
 import AppMap from "can-ssr/app-map";
+import 'can/route/pushstate/';
 
 import 'can/map/define/';
 


### PR DESCRIPTION
Let's History API based routing work for the SPA.

Serves public from root, so `http://localhost:8080/public/tasks` can work as `http://localhost:8080/tasks`
