### PR TITLE
Add rewrite rule for tests

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -23,7 +23,18 @@ module.exports = {
     "watchOptions": {},
     "server": true,
     "port": 8080,
-    "middleware": [ historyApiFallback() ],
+    "middleware": [ historyApiFallback({
+      rewrites: [
+        {
+          // serve static tests
+          from: /\/test\/$/,
+          to: function(context) {
+            console.log(context.parsedUrl.pathname);
+            return context.parsedUrl.pathname + 'index.html';
+          }
+        }
+      ]
+    }) ],
     "serveStatic": [
         'public',
         './'

--- a/bs-config.js
+++ b/bs-config.js
@@ -29,7 +29,6 @@ module.exports = {
           // serve static tests
           from: /\/test\/$/,
           to: function(context) {
-            console.log(context.parsedUrl.pathname);
             return context.parsedUrl.pathname + 'index.html';
           }
         }


### PR DESCRIPTION
Individual routes can be rewritten to bypass the `connect-history-api-fallback` api.

This commit adds an example use case of this to allow test redirects from `/*/test/` to `/*/test/index.html`.
